### PR TITLE
Update linter config and add build-protoc Makefile target

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ formatters:
   settings:
     goimports:
       local-prefixes:
-        - github.com/gosuda
+        - gosuda.org
 
 linters:
   default: standard

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ formatters:
   settings:
     goimports:
       local-prefixes:
-        - gosuda.org
+        - github.com/gosuda
 
 linters:
   default: standard
@@ -108,8 +108,6 @@ linters:
         - bytes.Buffer.Write
         - bytes.Buffer.WriteString
         - io.Copy
-        - context.WithTimeout
-        - context.WithCancel
         - log.Printf
         - log.Println
         - log.Print
@@ -123,7 +121,6 @@ linters:
         - atomic.StoreInt64
         - atomic.LoadInt64
         - rand.Read
-        - crypto/rand.Read
 
     gocritic:
       enabled-tags:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ formatters:
   settings:
     goimports:
       local-prefixes:
+        - github.com/gosuda
         - gosuda.org
 
 linters:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt vet lint test vuln tidy all run build build-wasm compress-wasm build-frontend build-tunnel build-server clean
+.PHONY: help fmt vet lint test vuln tidy all run build build-protoc build-wasm compress-wasm build-frontend build-tunnel build-server clean
 
 .DEFAULT_GOAL := help
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/metaphorics/portal/pull/2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Build system**
> - Adds `build-protoc` target to `Makefile` and documents it in `help`; generates Go code from protobufs via `protoc`.
> 
> **Linting/configuration**
> - Expands `.golangci.yml`: sets `goimports` `local-prefixes` (`github.com/gosuda`), enables additional linters and detailed settings (govet with strict shadowing, revive rules, gosec excludes, performance checks), and issue limits.
> - Adjusts `errcheck` exclusions (removes `context.WithTimeout/WithCancel` and `crypto/rand.Read`) to enforce checking.
> - Tweaks `gocritic` checks (adds `rangeValCopy` to disabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3606ba62cc4e1226db769fba8b9f5e869de74dba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->